### PR TITLE
refactor: Rename project configuration to projectId for clarity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,4 @@ AZURE_DEVOPS_PAT=
 
 # The project identifier (GUID)
 # Note: Use the project ID rather than the project name
-AZURE_DEVOPS_PROJECT=
+AZURE_DEVOPS_PROJECT_ID=

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add the following configuration to the `mcpServers` object:
       "env": {
         "AZURE_DEVOPS_ORG": "your-organization",
         "AZURE_DEVOPS_PAT": "your-personal-access-token",
-        "AZURE_DEVOPS_PROJECT": "your-project-name"
+        "AZURE_DEVOPS_PROJECT_ID": "your-project-id"
       },
       "disabled": false,
       "autoApprove": []
@@ -91,7 +91,7 @@ Replace the following values:
 
 - `/absolute/path/to/azure-devops-server`: The absolute path to where you cloned this repository
 - `your-organization`: Your Azure DevOps organization name
-- `your-project-name`: Your Azure DevOps project name
+- `your-project-id`: Your Azure DevOps project ID
 - `your-personal-access-token`: The PAT you generated in step 1
 
 ## Available Tools
@@ -186,7 +186,7 @@ npm run inspector
 2. If you get authentication errors:
    - Verify your PAT hasn't expired
    - Ensure the PAT has all necessary scopes
-   - Double-check the organization and project names
+   - Double-check the organization and project ID
 
 3. For other issues:
    - Run the inspector tool to verify the server is working correctly

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -10,9 +10,9 @@ startCommand:
       org:
         type: string
         description: Azure DevOps Organization name
-      project:
+      projectId:
         type: string
-        description: Azure DevOps Project name
+        description: Azure DevOps Project ID
   commandFunction: |
     function getCommand(config) {
       return {
@@ -21,7 +21,7 @@ startCommand:
         env: {
           AZURE_DEVOPS_PAT: config.pat,
           AZURE_DEVOPS_ORG: config.org,
-          AZURE_DEVOPS_PROJECT: config.project
+          AZURE_DEVOPS_PROJECT_ID: config.projectId
         }
       };
     }

--- a/src/api/wiki.ts
+++ b/src/api/wiki.ts
@@ -36,7 +36,7 @@ export class WikiApi {
   constructor(connection: WebApi, config: AzureDevOpsConfig) {
     this.connection = connection;
     this.config = config;
-    this.baseUrl = `${config.orgUrl}/${config.project}/_apis/wiki`;
+    this.baseUrl = `${config.orgUrl}/${config.projectId}/_apis/wiki`;
   }
 
   private async getAuthHeader(): Promise<string> {
@@ -54,7 +54,7 @@ export class WikiApi {
       },
       body: JSON.stringify({
         name,
-        projectId: projectId || this.config.project,
+        projectId: projectId || this.config.projectId,
         type: 'projectWiki',
         mappedPath: mappedPath || '/',
       }),

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -4,7 +4,7 @@ import { ConfigurationError } from '../errors.js';
 export interface AzureDevOpsConfig {
   pat: string;
   org: string;
-  project: string;
+  projectId: string;
   orgUrl: string;
 }
 
@@ -27,8 +27,8 @@ export function createConfig(options?: Partial<AzureDevOpsConfig>): AzureDevOpsC
     'Organization (org)'
   );
   const PROJECT = validateConfigValue(
-    options?.project ?? env.AZURE_DEVOPS_PROJECT,
-    'Project (project)'
+    options?.projectId ?? env.AZURE_DEVOPS_PROJECT_ID,
+    'Project (projectId)'
   );
 
   if (!ORG.match(/^[a-zA-Z0-9-_]+$/)) {
@@ -40,7 +40,7 @@ export function createConfig(options?: Partial<AzureDevOpsConfig>): AzureDevOpsC
   return {
     pat: PAT,
     org: ORG,
-    project: PROJECT,
+    projectId: PROJECT,
     orgUrl: `https://dev.azure.com/${ORG}`,
   };
 }

--- a/src/tools/board/get.ts
+++ b/src/tools/board/get.ts
@@ -11,8 +11,8 @@ export async function getBoards(args: GetBoardsArgs, config: AzureDevOpsConfig) 
   const workApi = await connection.getWorkApi();
   
   const teamContext = {
-    project: config.project,
-    team: args.team || `${config.project} Team`,
+    project: config.projectId,
+    team: args.team || `${config.projectId} Team`,
   };
 
   const boards = await workApi.getBoards(teamContext);

--- a/src/tools/git/list.ts
+++ b/src/tools/git/list.ts
@@ -8,7 +8,7 @@ export async function listRepositories(config: AzureDevOpsConfig) {
   const gitApi = await connection.getGitApi();
 
   try {
-    const repositories = await gitApi.getRepositories(config.project);
+    const repositories = await gitApi.getRepositories(config.projectId);
     
     // Format repository information
     const formattedRepos = repositories.map(repo => ({

--- a/src/tools/pipeline/get.ts
+++ b/src/tools/pipeline/get.ts
@@ -14,7 +14,7 @@ export async function getPipelines(args: GetPipelinesArgs, config: AzureDevOpsCo
 
   try {
     const pipelines = await pipelineApi.getDefinitions(
-      config.project,
+      config.projectId,
       args.name,
       args.folder
     );

--- a/src/tools/pipeline/trigger.ts
+++ b/src/tools/pipeline/trigger.ts
@@ -20,7 +20,7 @@ export async function triggerPipeline(args: TriggerPipelineArgs, config: AzureDe
   try {
     // Get pipeline definition first
     const definition = await pipelineApi.getDefinition(
-      config.project,
+      config.projectId,
       args.pipelineId
     );
 
@@ -42,7 +42,7 @@ export async function triggerPipeline(args: TriggerPipelineArgs, config: AzureDe
     };
 
     // Queue new build
-    const queuedBuild = await pipelineApi.queueBuild(build, config.project);
+    const queuedBuild = await pipelineApi.queueBuild(build, config.projectId);
 
     return {
       content: [

--- a/src/tools/pull-request/create.ts
+++ b/src/tools/pull-request/create.ts
@@ -36,7 +36,7 @@ export async function createPullRequest(args: CreatePullRequestArgs, config: Azu
     const createdPr = await gitApi.createPullRequest(
       pullRequestToCreate,
       args.repositoryId,
-      config.project
+      config.projectId
     );
 
     return {

--- a/src/tools/pull-request/getById.ts
+++ b/src/tools/pull-request/getById.ts
@@ -17,7 +17,7 @@ export async function getPullRequest(args: GetPullRequestArgs, config: AzureDevO
 
   try {
     // Get specific PR by ID
-    const pullRequest = await gitApi.getPullRequestById(args.pullRequestId, config.project);
+    const pullRequest = await gitApi.getPullRequestById(args.pullRequestId, config.projectId);
     
     if (!pullRequest) {
       throw new McpError(

--- a/src/tools/pull-request/update.ts
+++ b/src/tools/pull-request/update.ts
@@ -26,7 +26,7 @@ export async function updatePullRequest(args: UpdatePullRequestArgs, config: Azu
 
   try {
     // Get current PR
-    const currentPr = await gitApi.getPullRequestById(args.pullRequestId, config.project);
+    const currentPr = await gitApi.getPullRequestById(args.pullRequestId, config.projectId);
     if (!currentPr) {
       throw new McpError(
         ErrorCode.InvalidParams,
@@ -90,7 +90,7 @@ export async function updatePullRequest(args: UpdatePullRequestArgs, config: Azu
       prUpdate,
       currentPr.repository.id,
       args.pullRequestId,
-      config.project
+      config.projectId
     );
 
     return {

--- a/src/tools/wiki/create.ts
+++ b/src/tools/wiki/create.ts
@@ -21,12 +21,12 @@ export async function createWiki(args: CreateWikiArgs, config: AzureDevOpsConfig
   try {
     const wikiCreateParams = {
       name: args.name,
-      projectId: args.projectId || config.project,
+      projectId: args.projectId || config.projectId,
       mappedPath: args.mappedPath || '/',
       type: WikiType.ProjectWiki,
     };
 
-    const wiki = await wikiApi.createWiki(wikiCreateParams, config.project);
+    const wiki = await wikiApi.createWiki(wikiCreateParams, config.projectId);
 
     return {
       content: [

--- a/src/tools/wiki/get.ts
+++ b/src/tools/wiki/get.ts
@@ -14,7 +14,7 @@ export async function getWikis(args: Record<string, never>, config: AzureDevOpsC
   const connection = AzureDevOpsConnection.getInstance();
   const wikiApi = await connection.getWikiApi();
   
-  const wikis = await wikiApi.getAllWikis(config.project);
+  const wikis = await wikiApi.getAllWikis(config.projectId);
 
   return {
     content: [
@@ -40,7 +40,7 @@ export async function getWikiPage(args: GetWikiPageArgs, config: AzureDevOpsConf
 
   try {
     // Get wiki information
-    const wiki = await wikiApi.getWiki(config.project, args.wikiIdentifier);
+    const wiki = await wikiApi.getWiki(config.projectId, args.wikiIdentifier);
     if (!wiki || !wiki.id) {
       throw new McpError(
         ErrorCode.InvalidParams,

--- a/src/tools/wiki/update.ts
+++ b/src/tools/wiki/update.ts
@@ -22,7 +22,7 @@ export async function updateWikiPage(args: UpdateWikiPageArgs, config: AzureDevO
   const wikiApi = await connection.getWikiApi();
 
   try {
-    const wiki = await wikiApi.getWiki(config.project, args.wikiIdentifier);
+    const wiki = await wikiApi.getWiki(config.projectId, args.wikiIdentifier);
     if (!wiki || !wiki.id) {
       throw new McpError(
         ErrorCode.InvalidParams,

--- a/src/tools/work-item/create.ts
+++ b/src/tools/work-item/create.ts
@@ -15,7 +15,7 @@ export async function createWorkItem(args: { type: string; document: JsonPatchOp
   const workItem = await workItemTrackingApi.createWorkItem(
     undefined,
     args.document,
-    config.project,
+    config.projectId,
     args.type
   );
 

--- a/src/tools/work-item/get.ts
+++ b/src/tools/work-item/get.ts
@@ -17,7 +17,7 @@ export async function getWorkItem(args: WorkItemBatchGetRequest, config: AzureDe
     args.asOf,
     WorkItemExpand.All,
     args.errorPolicy,
-    config.project
+    config.projectId
   );
 
   return {

--- a/src/tools/work-item/list.ts
+++ b/src/tools/work-item/list.ts
@@ -14,7 +14,7 @@ export async function listWorkItems(args: Wiql, config: AzureDevOpsConfig) {
   
   const queryResult = await workItemTrackingApi.queryByWiql(
     args,
-    { project: config.project }
+    { project: config.projectId }
   );
 
   return {

--- a/src/tools/work-item/update.ts
+++ b/src/tools/work-item/update.ts
@@ -17,7 +17,7 @@ export async function updateWorkItem(args: { id: number; document: JsonPatchOper
     undefined,
     args.document,
     args.id,
-    config.project
+    config.projectId
   );
 
   return {


### PR DESCRIPTION
- Updated environment variable from AZURE_DEVOPS_PROJECT to AZURE_DEVOPS_PROJECT_ID in .env.example and README.md.
- Refactored code across multiple files to replace instances of 'project' with 'projectId' for consistency in Azure DevOps configuration.
- Ensured all related functions and API calls are aligned with the new naming convention, enhancing clarity and reducing potential confusion.